### PR TITLE
Correcting time counting for flexible mode

### DIFF
--- a/example/online/config.py
+++ b/example/online/config.py
@@ -48,7 +48,7 @@ ny = 18
 # initial time step
 init_step = 0
 # total number of time steps
-nsteps:int = 19
+nsteps:int = 18
 
 #### filter options ####
 # number of ensemble members

--- a/example/online/model_integrator.py
+++ b/example/online/model_integrator.py
@@ -37,6 +37,7 @@ class model_integrator:
                         self.model_ens[i].field_p = self.step(self.model_ens[i].field_p, PDAF_system.pe, current_step + 1, config.USE_PDAF)
                     current_step += 1
 
+                current_step -= 1
                 PDAF_system.assimilate_flexible()
             else:
                 for i in range(PDAF_system.pe.dim_ens_l):

--- a/example/online/model_integrator.py
+++ b/example/online/model_integrator.py
@@ -37,12 +37,11 @@ class model_integrator:
                         self.model_ens[i].field_p = self.step(self.model_ens[i].field_p, PDAF_system.pe, current_step + 1, config.USE_PDAF)
                     current_step += 1
 
-                current_step -= 1
                 PDAF_system.assimilate_flexible()
             else:
                 for i in range(PDAF_system.pe.dim_ens_l):
                     self.model_ens[i].field_p = self.step(self.model_ens[i].field_p, PDAF_system.pe, current_step + 1, config.USE_PDAF)
-            current_step += 1
+                current_step += 1
 
     def step(self, field_p:np.ndarray, pe, step:int, USE_PDAF:bool) -> np.ndarray:
         """shifting model forward 'integration'


### PR DESCRIPTION
Hi Yumeng,

in example/online the time counter was increased by one at the analysis time when using the flexible mode. It looks like one has to subtract 1 from 'currrent_step' at the analysis time, which is done in this pull request.